### PR TITLE
Add empty array check before function count() call

### DIFF
--- a/src/Action/FetchAction.php
+++ b/src/Action/FetchAction.php
@@ -50,7 +50,7 @@ class FetchAction
      */
     protected function throwErrorOnNoResults($results, $message)
     {
-        if (! $results || count($results) === 0) {
+        if (! $results || (is_array($results) && count($results) === 0)) {
             throw new ApiInvalidRequestException(
                 $message
             );


### PR DESCRIPTION
Fix issue #75 (Countable exception on PHP 7.2).
Add empty array check - using function count() on empty array throws an exception on PHP 7.2.
Issue: https://github.com/xiaohutai/jsonapi/issues/75